### PR TITLE
Add staging model for orders table

### DIFF
--- a/models/staging/jaffle_shop/stg_jaffle_shop__orders.sql
+++ b/models/staging/jaffle_shop/stg_jaffle_shop__orders.sql
@@ -1,0 +1,26 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+with source as (
+
+    select * from {{ source('jaffle_shop', 'orders') }}
+
+),
+
+renamed as (
+
+    select
+        id as order_id,
+        user_id as customer_id,
+        order_date,
+        status,
+        current_timestamp() as _loaded_at
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
### Summary
Introduces `stg_orders.sql` as part of the staging layer for the orders dataset.

### Changes
- Renames raw fields for clarity (e.g. `user_id` → `customer_id`)
- Adds `_loaded_at` metadata column
- Prepares clean, audit-friendly data for downstream modeling

### Notes
- Uses `{{ source('jaffle_shop', 'orders') }}` for maintainable source abstraction
- All transformations limited to structural clean-up (no business logic)
