### PR TITLE
add stg_jaffle_shop__payments model for Stripe transactions

### DIFF
--- a/models/staging/jaffle_shop/stg_jaffle_shop__payments.sql
+++ b/models/staging/jaffle_shop/stg_jaffle_shop__payments.sql
@@ -1,0 +1,29 @@
+{{
+  config(
+    materialized='view'
+  )
+}}
+
+with source as (
+
+    select * from {{ source('stripe', 'payments') }}
+
+),
+
+renamed as (
+
+    select
+        id as payment_id,
+        order_id,
+        payment_method,
+
+-- Convert from cents to dollars
+        amount / 100.0 as amount,
+
+        current_timestamp() as _loaded_at
+
+    from source
+
+)
+
+select * from renamed


### PR DESCRIPTION
### Summary
Adds `stg_jaffle_shop__payments` to stage Stripe payment data.

### Changes
- Renamed and cleaned raw payment fields
- Converted amount to dollars
- Added `_loaded_at` metadata field
