### PR TITLE
Add intermediate model for order-level revenue summary

### DIFF
--- a/models/intermediate/int_jaffle_shop__customer_order_summary.sql
+++ b/models/intermediate/int_jaffle_shop__customer_order_summary.sql
@@ -1,0 +1,43 @@
+{{
+    config(
+        materialized='view'
+    )
+}}
+
+with payments as (
+
+    select * from {{ ref("stg_jaffle_shop__payments") }}
+
+),
+
+orders as (
+
+    select * from {{ ref('stg_jaffle_shop__orders') }}
+
+),
+
+order_payments as (
+
+    select
+        order_id,
+        sum(amount) as order_amount
+    from payments
+    where amount > 0
+    group by order_id
+
+),
+
+order_summary as (
+
+    select
+        o.order_id,
+        o.customer_id,
+        o.order_date,
+        o.status,
+        coalesce(op.order_amount, 0) as order_amount
+    from orders o
+    left join order_payments op on o.order_id = op.order_id
+
+)
+
+select * from order_summary


### PR DESCRIPTION
### Summary
Adds `int_customer_order_summary` model to calculate per-order revenue by combining clean orders and payments staging models.

### Purpose
Prepares input for customer-level revenue analysis and segmentation in the mart layer.

### Key Logic
- Filters out 0-amount payments
- Calculates revenue per order
- Joins with order metadata from `stg_jaffle_shop__orders`
